### PR TITLE
chore: my big fat irish refactor to reduce infinispan queries

### DIFF
--- a/scripts/push.sh
+++ b/scripts/push.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 printf "\n\n######## phone-server push ########\n"
 
-IMAGE_REPOSITORY=${PHONE_SERVER_IMAGE_REPOSITORY:-quay.io/redhatdemo/2021-game-server:latest}
+IMAGE_REPOSITORY=${IMAGE_REPOSITORY:-quay.io/redhatdemo/2021-game-server:latest}
 
 echo "Pushing ${IMAGE_REPOSITORY}"
 docker push ${IMAGE_REPOSITORY}

--- a/src/cloud-events/send.ts
+++ b/src/cloud-events/send.ts
@@ -4,7 +4,7 @@ import log from '@app/log';
 import { ShipType } from '@app/game/types';
 import { http } from '@app/utils';
 import { HTTPError } from 'got';
-import Player, { PlayerPositionData } from '@app/models/player';
+import MatchPlayer, { PlayerPositionData } from '@app/models/match.player';
 import { PredictionData } from '@app/payloads/incoming';
 import GameConfiguration from '@app/models/game.configuration';
 import MatchInstance from '@app/models/match.instance';
@@ -115,8 +115,8 @@ async function sendEvent(
 export function matchStart(
   game: GameConfiguration,
   match: MatchInstance,
-  playerA: Player,
-  playerB: Player
+  playerA: MatchPlayer,
+  playerB: MatchPlayer
 ): Promise<void> {
   const evt: MatchStartEventData = {
     game: game.getUUID(),
@@ -131,8 +131,8 @@ export function matchStart(
 export function attack(
   game: GameConfiguration,
   match: MatchInstance,
-  by: Player,
-  against: Player,
+  by: MatchPlayer,
+  against: MatchPlayer,
   attackResult: AttackResult,
   prediction?: PredictionData
 ): Promise<void> {
@@ -155,7 +155,7 @@ export function attack(
 export function bonus(
   game: GameConfiguration,
   match: MatchInstance,
-  player: Player,
+  player: MatchPlayer,
   bonusHitsCount: number
 ): Promise<void> {
   const evt: BonusAttackEventData = {
@@ -171,8 +171,8 @@ export function bonus(
 export function matchEnd(
   game: GameConfiguration,
   match: MatchInstance,
-  winner: Player,
-  loser: Player
+  winner: MatchPlayer,
+  loser: MatchPlayer
 ): Promise<void> {
   const evt: MatchEndEventData = {
     game: game.getUUID(),
@@ -190,7 +190,7 @@ export function matchEnd(
  * @param prediction
  */
 function toAttackingPlayerData(
-  player: Player,
+  player: MatchPlayer,
   prediction?: PredictionData
 ): AttackingPlayerData {
   return {
@@ -205,7 +205,7 @@ function toAttackingPlayerData(
  * Utility function to create an BasePlayerData structured type.
  * @param player
  */
-function toBasePlayerData(player: Player): BasePlayerData {
+function toBasePlayerData(player: MatchPlayer): BasePlayerData {
   return {
     username: player.getUsername(),
     uuid: player.getUUID(),

--- a/src/cloud-events/send.ts
+++ b/src/cloud-events/send.ts
@@ -54,8 +54,8 @@ type AttackEventData = EventBase & {
 };
 
 type BonusAttackEventData = EventBase & {
-  by: string;
-  bonusHitsCount: number;
+  by: Omit<BasePlayerData, 'board'>;
+  shots: number;
 };
 
 /**
@@ -156,16 +156,20 @@ export function bonus(
   game: GameConfiguration,
   match: MatchInstance,
   player: MatchPlayer,
-  bonusHitsCount: number
+  shots: number
 ): Promise<void> {
   const evt: BonusAttackEventData = {
     game: game.getUUID(),
     match: match.getUUID(),
-    by: player.getUUID(),
-    bonusHitsCount
+    by: {
+      username: player.getUsername(),
+      uuid: player.getUUID(),
+      human: !player.isAiPlayer()
+    },
+    shots
   };
 
-  return sendEvent(EventType.Attack, evt);
+  return sendEvent(EventType.Bonus, evt);
 }
 
 export function matchEnd(

--- a/src/config.ts
+++ b/src/config.ts
@@ -59,6 +59,9 @@ const config = {
   DATAGRID_PLAYER_DATA_STORE: get('DATAGRID_PLAYER_DATA_STORE')
     .default('players')
     .asString(),
+  DATAGRID_MATCH_DATA_STORE: get('DATAGRID_MATCH_DATA_STORE')
+    .default('match-instances')
+    .asString(),
   DATAGRID_HOST: get('DATAGRID_HOST').default('infinispan').asString(),
   DATAGRID_HOTROD_PORT: get('DATAGRID_HOTROD_PORT')
     .default(11222)

--- a/src/datagrid/client.ts
+++ b/src/datagrid/client.ts
@@ -49,11 +49,6 @@ export default async function getDataGridClientForCacheNamed(
       (key) => eventHandler(client, 'modify', key),
       { listenerId }
     );
-    await client.addListener(
-      'remove',
-      (key) => eventHandler(client, 'remove', key),
-      { listenerId }
-    );
   }
 
   return client;

--- a/src/game/index.ts
+++ b/src/game/index.ts
@@ -1,6 +1,6 @@
 import { GAME_GRID_SIZE } from '@app/config';
 import log from '@app/log';
-import Player from '@app/models/player';
+import MatchPlayer from '@app/models/match.player';
 import {
   ShipType,
   ShipSize,
@@ -148,7 +148,7 @@ function populateGridWithShipData(size: number, ship: ShipData, grid: Grid) {
  * cells have been hit, and thus all their ships are destroyed
  * @param {Player} player
  */
-export function isGameOverForPlayer(player: Player): boolean {
+export function isGameOverForPlayer(player: MatchPlayer): boolean {
   const shipPositions = player.getShipPositionData();
 
   log.trace(

--- a/src/ml/index.ts
+++ b/src/ml/index.ts
@@ -2,13 +2,13 @@ import { NODE_ENV } from '@app/config';
 import log from '@app/log';
 import GameConfiguration from '@app/models/game.configuration';
 import MatchInstance from '@app/models/match.instance';
-import Player from '@app/models/player';
+import MatchPlayer from '@app/models/match.player';
 import { AWS_BUCKET_NAME } from '@app/config';
 import { getStorageInstance } from './s3';
 
 export function writeGameRecord(
-  winner: Player,
-  loser: Player,
+  winner: MatchPlayer,
+  loser: MatchPlayer,
   match: MatchInstance,
   game: GameConfiguration
 ) {

--- a/src/models/match.instance.ts
+++ b/src/models/match.instance.ts
@@ -1,14 +1,18 @@
 import assert from 'assert';
 import log from '@app/log';
 import Model from './model';
-import Player from './player';
+import MatchPlayer, { MatchPlayerData } from './match.player';
+import Player, { UnmatchedPlayerData, PlayerData } from './player';
 import { ShipType } from '@app/game/types';
+
+type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;
 
 type TurnState = {
   phase: MatchPhase;
 
   // The player whose UUID is set here is allowed to attack
   activePlayer: string;
+
   // If the bonus is set to a ship type then the client will
   // trigger a bonus round attack against that ship
   bonus?: ShipType;
@@ -25,8 +29,8 @@ export type MatchInstanceData = {
   uuid: string;
 
   // These for the player's "uuid" values, not their usernames
-  playerA: string;
-  playerB?: string;
+  playerA: MatchPlayerData;
+  playerB?: MatchPlayerData;
 
   state: TurnState;
 
@@ -34,22 +38,45 @@ export type MatchInstanceData = {
   winner?: string;
 };
 
+export type MatchInstanceFrontendData = {
+  uuid: string;
+  winner?: string;
+  state: Optional<TurnState, 'activePlayer'>;
+};
+
 export default class MatchInstance extends Model<MatchInstanceData> {
   private state: TurnState;
+  private playerA: MatchPlayer;
+  private playerB?: MatchPlayer;
 
   constructor(
-    private playerA: string,
-    private playerB?: string,
+    playerA: UnmatchedPlayerData | MatchPlayer,
+    playerB?: UnmatchedPlayerData | MatchPlayer,
     state?: TurnState,
     private winner?: string,
     uuid?: string
   ) {
     super(uuid);
 
+    if (playerA instanceof MatchPlayer) {
+      this.playerA = playerA;
+    } else {
+      this.playerA = createMatchPlayerFromPlayerAndMatch(playerA, this);
+    }
+
+    if (playerB) {
+      if (playerB instanceof MatchPlayer) {
+        this.playerB = playerB;
+      } else {
+        this.playerB = createMatchPlayerFromPlayerAndMatch(playerB, this);
+      }
+    }
+
     if (!state) {
       this.state = {
         phase: MatchPhase.NotReady,
-        activePlayer: playerA
+        activePlayer:
+          playerA instanceof MatchPlayer ? playerA.getUUID() : playerA.uuid
       };
     } else {
       this.state = state;
@@ -59,22 +86,24 @@ export default class MatchInstance extends Model<MatchInstanceData> {
   static from(data: MatchInstanceData) {
     log.trace('creating match instance from data: %j', data);
     return new MatchInstance(
-      data.playerA,
-      data.playerB,
+      MatchPlayer.from(data.playerA),
+      data.playerB ? MatchPlayer.from(data.playerB) : undefined,
       data.state,
       data.winner,
       data.uuid
     );
   }
 
-  addPlayer(player: Player) {
+  addPlayer(player: UnmatchedPlayerData) {
     if (this.playerB) {
       throw new Error(
-        `match ${this.getUUID()} full, cannot add player ${player.getUUID()}`
+        `match ${this.getUUID()} full, cannot add player ${player.uuid}`
       );
     }
 
-    this.playerB = player.getUUID();
+    log.info(`adding player ${player.uuid} to match ${this.getUUID()}`);
+
+    this.playerB = createMatchPlayerFromPlayerAndMatch(player, this);
   }
 
   isJoinable(): boolean {
@@ -85,7 +114,7 @@ export default class MatchInstance extends Model<MatchInstanceData> {
     return this.state.phase === p;
   }
 
-  isPlayerTurn(player: Player) {
+  isPlayerTurn(player: MatchPlayer) {
     return this.state.activePlayer === player.getUUID();
   }
 
@@ -97,7 +126,7 @@ export default class MatchInstance extends Model<MatchInstanceData> {
     return this.state.phase;
   }
 
-  setWinner(player: Player) {
+  setWinner(player: MatchPlayer) {
     const uuid = player.getUUID();
     log.info(`setting ${uuid} as the winner for match ${this.getUUID()}`);
     this.winner = uuid;
@@ -117,10 +146,16 @@ export default class MatchInstance extends Model<MatchInstanceData> {
       assert('changeTurn() was called, but match is not yet ready');
     }
 
-    if (this.state.activePlayer === this.playerA && this.playerB) {
-      this.state = { phase: MatchPhase.Attack, activePlayer: this.playerB };
+    if (this.state.activePlayer === this.playerA.getUUID() && this.playerB) {
+      this.state = {
+        phase: MatchPhase.Attack,
+        activePlayer: this.playerB.getUUID()
+      };
     } else {
-      this.state = { phase: MatchPhase.Attack, activePlayer: this.playerA };
+      this.state = {
+        phase: MatchPhase.Attack,
+        activePlayer: this.playerA.getUUID()
+      };
     }
 
     log.trace(
@@ -137,28 +172,85 @@ export default class MatchInstance extends Model<MatchInstanceData> {
     };
   }
 
-  getPlayerOpponentUUID(player: Player) {
-    const playerUUID = player.getUUID();
+  getMatchPlayerInstanceByUUID(uuid: string): MatchPlayer | undefined {
+    const aUUID = this.playerA.getUUID();
+    const bUUID = this.playerB?.getUUID();
 
-    if (playerUUID === this.playerA) {
+    if (uuid === aUUID) {
+      return this.playerA;
+    } else if (uuid === bUUID) {
       return this.playerB;
-    } else if (playerUUID === this.playerB) {
+    } else {
+      // This should not happen, but if it does we need to know
+      throw new Error(
+        `tried to find player ${uuid} in match ${this.getUUID()}, but only players [${aUUID}, ${bUUID}] are in this match!`
+      );
+    }
+  }
+
+  getPlayerOpponent(player: Player | MatchPlayer): MatchPlayer | undefined {
+    const playerUUID = player.getUUID();
+    const aUUID = this.playerA.getUUID();
+    const bUUID = this.playerB?.getUUID();
+
+    if (playerUUID === aUUID) {
+      return this.playerB;
+    } else if (playerUUID === bUUID) {
       return this.playerA;
     } else {
       // This should not happen, but if it does we need to know
       throw new Error(
-        `tried to find opponent for player ${playerUUID} in match ${this.getUUID()}, but this player is not associated with this match!`
+        `tried to find opponent for player ${playerUUID} in match ${this.getUUID()}, but players [${aUUID}, ${bUUID}] are in this match!`
       );
     }
+  }
+
+  getPlayerOpponentUUID(player: Player): string | undefined {
+    return this.getPlayerOpponent(player)?.getUUID();
   }
 
   toJSON(): MatchInstanceData {
     return {
       uuid: this.getUUID(),
-      playerA: this.playerA,
-      playerB: this.playerB,
+      playerA: this.playerA.toJSON(),
+      playerB: this.playerB?.toJSON(),
       state: this.state,
       winner: this.winner
     };
   }
+
+  /**
+   * Formats the match instance data for transmission to the client.
+   *
+   * We need to remove the activePlayer key if it's not equal to the given
+   * player ID. This is because the UUID is treated as a secret...
+   *
+   * ...we should probably change that -_-
+   *
+   * @param player
+   * @returns
+   */
+  toFrontendJsonForPlayer(player: string): MatchInstanceFrontendData {
+    const data: MatchInstanceFrontendData = {
+      uuid: this.getUUID(),
+      state: { ...this.state },
+      winner: this.winner
+    };
+
+    if (data.state.activePlayer !== player) {
+      delete data.state.activePlayer;
+    }
+
+    return data;
+  }
+}
+
+function createMatchPlayerFromPlayerAndMatch(
+  player: UnmatchedPlayerData,
+  match: MatchInstance
+): MatchPlayer {
+  return new MatchPlayer({
+    ...player,
+    match: match.getUUID()
+  });
 }

--- a/src/models/match.instance.ts
+++ b/src/models/match.instance.ts
@@ -2,7 +2,7 @@ import assert from 'assert';
 import log from '@app/log';
 import Model from './model';
 import MatchPlayer, { MatchPlayerData } from './match.player';
-import Player, { UnmatchedPlayerData, PlayerData } from './player';
+import Player, { UnmatchedPlayerData } from './player';
 import { ShipType } from '@app/game/types';
 
 type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;

--- a/src/models/match.instance.ts
+++ b/src/models/match.instance.ts
@@ -128,7 +128,9 @@ export default class MatchInstance extends Model<MatchInstanceData> {
 
   setWinner(player: MatchPlayer) {
     const uuid = player.getUUID();
-    log.info(`setting ${uuid} as the winner for match ${this.getUUID()}`);
+    log.info(
+      `setting ${uuid} (ai: ${player.isAiPlayer()}) as the winner for match ${this.getUUID()}`
+    );
     this.winner = uuid;
   }
 

--- a/src/models/match.player.ts
+++ b/src/models/match.player.ts
@@ -1,0 +1,367 @@
+import { AttackDataPayload } from '@app/payloads/incoming';
+import {
+  getCellCoverageForOriginOrientationAndArea,
+  getRandomShipLayout,
+  isSameOrigin
+} from '@app/utils';
+import {
+  CellPosition,
+  Orientation,
+  ShipSize,
+  ShipPositionData,
+  ShipType
+} from '@app/game/types';
+import Model from './model';
+import { AttackResult, AttackResultHitDestroy } from '@app/payloads/common';
+import log from '@app/log';
+
+/**
+ * The location and hit status of a ship cell. A ship will cover multiple cells
+ * on the board, so we track them individually over time.
+ */
+type StoredShipDataCell = {
+  origin: CellPosition;
+  hit: boolean;
+  type: ShipType;
+};
+
+/**
+ * Player attacks are stored. These are used by the client to render the game
+ * board at any point in time.
+ */
+type StoredAttackData = {
+  ts: number;
+  attack: AttackDataPayload;
+  result: AttackResult;
+};
+
+/**
+ * The ship data that is stored includes the cells and their current state,
+ * i.e if they have been hit by an attack
+ */
+export type StoredShipData = {
+  type: ShipType;
+  origin: CellPosition;
+  orientation: Orientation;
+  cells: StoredShipDataCell[];
+};
+
+/**
+ * Container type to store player ship position data.
+ */
+export type PlayerPositionData = {
+  [key in ShipType]: StoredShipData;
+};
+
+/**
+ * The opponent ship placements (from the perspective of another player) are
+ * only revealed after the particular ship has been completely destroyed
+ */
+type OpponentPositionData = {
+  [key in ShipType]?: StoredShipData;
+};
+
+/**
+ * A player's board data must be validated. So we store it alongside a flag
+ * that indicates if it has passed validation.
+ */
+type MatchPlayerBoardData = {
+  valid: boolean;
+  positions: PlayerPositionData;
+};
+
+/**
+ * A representation of the overall Player state. This is the type of data that
+ * inifinispan will hold for a Player instance, and is used to instantiate a
+ * Player object from cache entries.
+ */
+export type MatchPlayerData = {
+  uuid: string;
+  username: string;
+  isAi: boolean;
+  match: string;
+  board: MatchPlayerBoardData;
+  attacks: StoredAttackData[];
+};
+
+/**
+ * Similar to PlayerData, but contains a sanitised version of data top prevent
+ * a nefarious player from getting an upper hand by inspecting packets.
+ */
+export type MatchOpponentData = {
+  username: string;
+  attacks: StoredAttackData[];
+  board: OpponentPositionData;
+};
+
+export default class MatchPlayer extends Model<MatchPlayerData> {
+  private board: MatchPlayerBoardData;
+  private attacks: StoredAttackData[];
+  private username: string;
+  private isAi: boolean;
+  private match: string;
+
+  constructor(opts: {
+    username: string;
+    isAi: boolean;
+    uuid: string;
+    match: string;
+    board?: MatchPlayerBoardData;
+    attacks?: StoredAttackData[];
+  }) {
+    super(opts.uuid);
+
+    this.match = opts.match;
+    this.attacks = opts.attacks || [];
+    this.username = opts.username;
+    this.isAi = opts.isAi;
+
+    if (opts.board) {
+      this.board = opts.board;
+    } else {
+      // Create a default set of valid, but not unconfirmed positions. The
+      // end-user will need to confirm them via the UI
+      this.board = {
+        valid: false,
+        positions: createPositionDataWithCells(getRandomShipLayout())
+      };
+    }
+  }
+
+  static from(data: MatchPlayerData) {
+    log.trace('creating MatchPlayer instance from data: %j', data);
+    return new MatchPlayer(data);
+  }
+
+  isAiPlayer() {
+    return this.isAi;
+  }
+
+  hasAttacked() {
+    return this.attacks.length > 0;
+  }
+
+  hasAttackedLocation(origin: CellPosition): boolean {
+    return !!this.attacks.find((a) => isSameOrigin(a.attack.origin, origin));
+  }
+
+  getShipPositionData() {
+    return this.board?.positions;
+  }
+
+  hasLockedValidShipPositions() {
+    return this.board?.valid;
+  }
+
+  setMatchInstanceUUID(uuid: string) {
+    log.trace(`setting player ${this.getUUID()} match UUID to ${uuid}`);
+    this.match = uuid;
+  }
+
+  getUsername() {
+    return this.username;
+  }
+
+  getMatchInstanceUUID() {
+    return this.match;
+  }
+
+  /**
+   * Return the number of shots that this player has fired so far.
+   */
+  getShotsFiredCount() {
+    return this.attacks.length;
+  }
+
+  /**
+   * Return the number of successive shots in a row that have been successful
+   * hits. This could be zero for most of the game if the player is unfortunate
+   * or unattentive.
+   */
+  getContinuousHitsCount() {
+    // Sort the attacks in order of most recent first
+    const attacksInTimeOrder = this.attacks
+      .slice()
+      .sort((a, b) => (a.ts > b.ts ? -1 : 1));
+
+    // Then increase the counter for each successful hit, then break the
+    // loop once a miss is detected
+    let count = 0;
+    for (const atk of attacksInTimeOrder) {
+      if (atk.result.hit) {
+        count++;
+      } else {
+        break;
+      }
+    }
+
+    return count;
+  }
+
+  /**
+   * Returns the information for all cells occupied by this player's ships
+   */
+  private getAllShipCells(): Array<StoredShipDataCell> {
+    return Object.keys(this.board.positions).reduce((agg, key) => {
+      const shipData = this.board.positions[key as ShipType];
+
+      shipData.cells.forEach((c) => agg.push(c));
+
+      return agg;
+    }, [] as Array<StoredShipDataCell>);
+  }
+
+  /**
+   * Take a validated set on incoming ship positions, initialise them for game
+   * logic, and store on this player instance.
+   * @param data
+   * @param valid
+   */
+  setShipPositionData(data: ShipPositionData, valid: boolean) {
+    log.debug(
+      `setting ship position data (valid: ${valid}) for player ${this.getUUID()} to: %j`,
+      data
+    );
+
+    this.board = {
+      valid,
+      positions: createPositionDataWithCells(data)
+    };
+  }
+
+  /**
+   * Determines if a given attack at an origin will hit/miss. It the attack is
+   * deemed to be a hit, it will also determine if it destroyed a ship.
+   *
+   * This is called if this player is the recipient of an attack.
+   */
+  determineAttackResult({ origin }: AttackDataPayload): AttackResult {
+    const cells = this.getAllShipCells();
+
+    const hitCell = cells.find((c) => isSameOrigin(c.origin, origin));
+
+    if (hitCell) {
+      // Mark cell as hit since we need to keep track of this!
+      hitCell.hit = true;
+
+      // Determine if this hit was the final one required to sink the ship
+      const destroyed = cells
+        .filter((c) => c.type === hitCell.type)
+        .reduce((_destroyed: boolean, v) => {
+          return _destroyed && v.hit;
+        }, true);
+
+      return {
+        ...hitCell,
+        destroyed
+      } as AttackResultHitDestroy;
+    } else {
+      return {
+        hit: false,
+        origin
+      };
+    }
+  }
+
+  /**
+   * Records the result of an attack in this player record. This is called if
+   * this player was the one making the attack.
+   */
+  recordAttackResult(attack: AttackDataPayload, result: AttackResult) {
+    this.attacks.push({
+      ts: Date.now(),
+      attack,
+      result
+    });
+  }
+
+  /**
+   * Generates a JSON object that has secret information redacted. This is
+   * necessary since players need to know certain information about their
+   * opponent, but we don't want to expose ship locations and other data
+   */
+  toOpponentJSON(): MatchOpponentData {
+    const board: OpponentPositionData = {};
+    const positions = this.board.positions;
+
+    if (positions) {
+      Object.keys(positions).forEach((_ship) => {
+        const type = _ship as ShipType;
+        const ship = positions[type];
+        const sunk = ship.cells.reduce(
+          (result, cell) => result && cell.hit,
+          true
+        );
+
+        if (sunk) {
+          // If the ship has been sunk expose it in returned data
+          board[type] = ship;
+        }
+      });
+    }
+
+    return {
+      username: this.username,
+      attacks: this.attacks.map((a) => {
+        const atk = {
+          ...a
+        };
+
+        // Remove prediction data from outgoing messages
+        delete a.attack.prediction;
+
+        return atk;
+      }),
+      board
+    };
+  }
+
+  /**
+   * Returns a JSON object that is used to serialise this Player instance for
+   * storage in the infinispan cache, or to be sent via WebSocket
+   */
+  toJSON(): MatchPlayerData {
+    return {
+      board: this.board,
+      isAi: this.isAi,
+      username: this.username,
+      match: this.getMatchInstanceUUID(),
+      attacks: this.attacks,
+      uuid: this.getUUID()
+    };
+  }
+}
+
+/**
+ * Take basic ShipPositionData and explode out the cells that each of the
+ * provided ships occupy, i.e the x,y coordinates that it covers.
+ * @param data
+ */
+function createPositionDataWithCells(
+  data: ShipPositionData
+): PlayerPositionData {
+  return Object.keys(data).reduce((updated, _type) => {
+    const type = _type as ShipType;
+    const shipData = data[type];
+
+    const cells = getCellCoverageForOriginOrientationAndArea(
+      shipData.origin,
+      shipData.orientation,
+      ShipSize[type]
+    );
+
+    updated[type] = {
+      ...shipData,
+      type,
+      cells: cells.map((origin) => {
+        return {
+          hit: false,
+          origin,
+          type
+        };
+      })
+    };
+
+    return updated;
+  }, {} as PlayerPositionData);
+}

--- a/src/models/player.configuration.ts
+++ b/src/models/player.configuration.ts
@@ -1,28 +1,32 @@
 import GameConfiguration, { GameConfigurationData } from './game.configuration';
-import MatchInstance, { MatchInstanceData } from './match.instance';
-import Player, { OpponentData, PlayerData } from './player';
+import MatchInstance, { MatchInstanceFrontendData } from './match.instance';
+import MatchPlayer, {
+  MatchOpponentData,
+  MatchPlayerData
+} from './match.player';
 
 export type PlayerConfigurationData = {
   game: GameConfigurationData;
-  player: PlayerData;
-  match: MatchInstanceData;
-  opponent?: OpponentData;
+  player: MatchPlayerData;
+  match: MatchInstanceFrontendData;
+  opponent?: MatchOpponentData;
 };
 
 export default class PlayerConfiguration {
   constructor(
     private game: GameConfiguration,
-    private player: Player,
-    private match: MatchInstance,
-    private opponent?: Player
+    private player: MatchPlayer,
+    private match: MatchInstance
   ) {}
 
   toJSON(): PlayerConfigurationData {
+    const opponent = this.match.getPlayerOpponent(this.player);
+
     return {
-      opponent: this.opponent?.toOpponentJSON(),
+      opponent: opponent?.toOpponentJSON(),
       game: this.game.toJSON(),
       player: this.player.toJSON(),
-      match: this.match.toJSON()
+      match: this.match.toFrontendJsonForPlayer(this.player.getUUID())
     };
   }
 }

--- a/src/models/player.ts
+++ b/src/models/player.ts
@@ -1,132 +1,32 @@
-import { AttackDataPayload } from '@app/payloads/incoming';
-import {
-  getCellCoverageForOriginOrientationAndArea,
-  getRandomShipLayout,
-  isSameOrigin
-} from '@app/utils';
-import {
-  CellPosition,
-  Orientation,
-  ShipSize,
-  ShipPositionData,
-  ShipType
-} from '@app/game/types';
 import Model from './model';
-import { AttackResult, AttackResultHitDestroy } from '@app/payloads/common';
 import log from '@app/log';
 
-/**
- * The location and hit status of a ship cell. A ship will cover multiple cells
- * on the board, so we track them individually over time.
- */
-type StoredShipDataCell = {
-  origin: CellPosition;
-  hit: boolean;
-  type: ShipType;
-};
-
-/**
- * Player attacks are stored. These are used by the client to render the game
- * board at any point in time.
- */
-type StoredAttackData = {
-  ts: number;
-  attack: AttackDataPayload;
-  result: AttackResult;
-};
-
-/**
- * The ship data that is stored includes the cells and their current state,
- * i.e if they have been hit by an attack
- */
-export type StoredShipData = {
-  type: ShipType;
-  origin: CellPosition;
-  orientation: Orientation;
-  cells: StoredShipDataCell[];
-};
-
-/**
- * Container type to store player ship position data.
- */
-export type PlayerPositionData = {
-  [key in ShipType]: StoredShipData;
-};
-
-/**
- * The opponent ship placements (from the perspective of another player) are
- * only revealed after the particular ship has been completely destroyed
- */
-type OpponentPositionData = {
-  [key in ShipType]?: StoredShipData;
-};
-
-/**
- * A player's board data must be validated. So we store it alongside a flag
- * that indicates if it has passed validation.
- */
-type PlayerBoardData = {
-  valid: boolean;
-  positions: PlayerPositionData;
-};
-
-/**
- * A representation of the overall Player state. This is the type of data that
- * inifinispan will hold for a Player instance, and is used to instantiate a
- * Player object from cache entries.
- */
-export type PlayerData = {
+export type UnmatchedPlayerData = {
   uuid: string;
   username: string;
   isAi: boolean;
-  match?: string;
-  board: PlayerBoardData;
-  attacks: StoredAttackData[];
 };
 
-/**
- * Similar to PlayerData, but contains a sanitised version of data top prevent
- * a nefarious player from getting an upper hand by inspecting packets.
- */
-export type OpponentData = {
-  uuid: string;
-  username: string;
-  attacks: StoredAttackData[];
-  board: OpponentPositionData;
+export type PlayerData = UnmatchedPlayerData & {
+  match: string;
 };
 
 export default class Player extends Model<PlayerData> {
-  private board: PlayerBoardData;
-  private attacks: StoredAttackData[];
   private username: string;
   private isAi: boolean;
-  private match?: string;
+  private match: string;
 
   constructor(opts: {
     username: string;
     isAi: boolean;
     uuid?: string;
-    match?: string;
-    board?: PlayerBoardData;
-    attacks?: StoredAttackData[];
+    match: string;
   }) {
     super(opts.uuid);
 
     this.match = opts.match;
-    this.attacks = opts.attacks || [];
     this.username = opts.username;
     this.isAi = opts.isAi;
-
-    if (opts.board) {
-      this.board = opts.board;
-    } else {
-      // Create a default set of valid, but not unconfirmed positions. The
-      // end-user will need to confirm them via the UI
-      this.board = {
-        valid: false,
-        positions: createPositionDataWithCells(getRandomShipLayout())
-      };
-    }
   }
 
   static from(data: PlayerData) {
@@ -138,27 +38,6 @@ export default class Player extends Model<PlayerData> {
     return this.isAi;
   }
 
-  hasAttacked() {
-    return this.attacks.length > 0;
-  }
-
-  hasAttackedLocation(origin: CellPosition): boolean {
-    return !!this.attacks.find((a) => isSameOrigin(a.attack.origin, origin));
-  }
-
-  getShipPositionData() {
-    return this.board?.positions;
-  }
-
-  hasLockedShipPositions() {
-    return this.board?.valid;
-  }
-
-  setMatchInstanceUUID(uuid: string) {
-    log.trace(`setting player ${this.getUUID()} match UUID to ${uuid}`);
-    this.match = uuid;
-  }
-
   getUsername() {
     return this.username;
   }
@@ -168,202 +47,15 @@ export default class Player extends Model<PlayerData> {
   }
 
   /**
-   * Return the number of shots that this player has fired so far.
-   */
-  getShotsFiredCount() {
-    return this.attacks.length;
-  }
-
-  /**
-   * Return the number of successive shots in a row that have been successful
-   * hits. This could be zero for most of the game if the player is unfortunate
-   * or unattentive.
-   */
-  getContinuousHitsCount() {
-    // Sort the attacks in order of most recent first
-    const attacksInTimeOrder = this.attacks
-      .slice()
-      .sort((a, b) => (a.ts > b.ts ? -1 : 1));
-
-    // Then increase the counter for each successful hit, then break the
-    // loop once a miss is detected
-    let count = 0;
-    for (const atk of attacksInTimeOrder) {
-      if (atk.result.hit) {
-        count++;
-      } else {
-        break;
-      }
-    }
-
-    return count;
-  }
-
-  /**
-   * Returns the information for all cells occupied by this player's ships
-   */
-  private getAllShipCells(): Array<StoredShipDataCell> {
-    return Object.keys(this.board.positions).reduce((agg, key) => {
-      const shipData = this.board.positions[key as ShipType];
-
-      shipData.cells.forEach((c) => agg.push(c));
-
-      return agg;
-    }, [] as Array<StoredShipDataCell>);
-  }
-
-  /**
-   * Take a validated set on incoming ship positions, initialise them for game
-   * logic, and store on this player instance.
-   * @param data
-   * @param valid
-   */
-  setShipPositionData(data: ShipPositionData, valid: boolean) {
-    log.debug(
-      `setting ship position data (valid: ${valid}) for player ${this.getUUID()} to: %j`,
-      data
-    );
-
-    this.board = {
-      valid,
-      positions: createPositionDataWithCells(data)
-    };
-  }
-
-  /**
-   * Determines if a given attack at an origin will hit/miss. It the attack is
-   * deemed to be a hit, it will also determine if it destroyed a ship.
-   *
-   * This is called if this player is the recipient of an attack.
-   */
-  determineAttackResult({ origin }: AttackDataPayload): AttackResult {
-    const cells = this.getAllShipCells();
-
-    const hitCell = cells.find((c) => isSameOrigin(c.origin, origin));
-
-    if (hitCell) {
-      // Mark cell as hit since we need to keep track of this!
-      hitCell.hit = true;
-
-      // Determine if this hit was the final one required to sink the ship
-      const destroyed = cells
-        .filter((c) => c.type === hitCell.type)
-        .reduce((_destroyed: boolean, v) => {
-          return _destroyed && v.hit;
-        }, true);
-
-      return {
-        ...hitCell,
-        destroyed
-      } as AttackResultHitDestroy;
-    } else {
-      return {
-        hit: false,
-        origin
-      };
-    }
-  }
-
-  /**
-   * Records the result of an attack in this player record. This is called if
-   * this player was the one making the attack.
-   */
-  recordAttackResult(attack: AttackDataPayload, result: AttackResult) {
-    this.attacks.push({
-      ts: Date.now(),
-      attack,
-      result
-    });
-  }
-
-  /**
-   * Generates a JSON object that has secret information redacted. This is
-   * necessary since players need to know certain information about their
-   * opponent, but we don't want to expose ship locations and other data
-   */
-  toOpponentJSON(): OpponentData {
-    const board: OpponentPositionData = {};
-    const positions = this.board.positions;
-
-    if (positions) {
-      Object.keys(positions).forEach((_ship) => {
-        const type = _ship as ShipType;
-        const ship = positions[type];
-        const sunk = ship.cells.reduce(
-          (result, cell) => result && cell.hit,
-          true
-        );
-
-        if (sunk) {
-          // If the ship has been sunk expose it in returned data
-          board[type] = ship;
-        }
-      });
-    }
-
-    return {
-      username: this.username,
-      attacks: this.attacks.map((a) => {
-        const atk = {
-          ...a
-        };
-
-        // Remove prediction data from outgoing messages
-        delete a.attack.prediction;
-
-        return atk;
-      }),
-      uuid: this.getUUID(),
-      board
-    };
-  }
-
-  /**
    * Returns a JSON object that is used to serialise this Player instance for
    * storage in the infinispan cache, or to be sent via WebSocket
    */
   toJSON(): PlayerData {
     return {
-      board: this.board,
       isAi: this.isAi,
       username: this.username,
-      match: this.getMatchInstanceUUID(),
-      attacks: this.attacks,
+      match: this.match,
       uuid: this.getUUID()
     };
   }
-}
-
-/**
- * Take basic ShipPositionData and explode out the cells that each of the
- * provided ships occupy, i.e the x,y coordinates that it covers.
- * @param data
- */
-function createPositionDataWithCells(
-  data: ShipPositionData
-): PlayerPositionData {
-  return Object.keys(data).reduce((updated, _type) => {
-    const type = _type as ShipType;
-    const shipData = data[type];
-
-    const cells = getCellCoverageForOriginOrientationAndArea(
-      shipData.origin,
-      shipData.orientation,
-      ShipSize[type]
-    );
-
-    updated[type] = {
-      ...shipData,
-      type,
-      cells: cells.map((origin) => {
-        return {
-          hit: false,
-          origin,
-          type
-        };
-      })
-    };
-
-    return updated;
-  }, {} as PlayerPositionData);
 }

--- a/src/plugins/events.ts
+++ b/src/plugins/events.ts
@@ -30,146 +30,146 @@ const eventsPlugin: FastifyPluginCallback = (server, options, done) => {
    * This endpoint is used to process received cloud events.
    * These events are forwarded to this service using a Knative Trigger.
    */
-  server.route({
-    method: 'POST',
-    url: '/event/trigger',
-    handler: (request, reply) => {
-      try {
-        const evt = RecvEvents.parse(request.headers, request.body);
+  // server.route({
+  //   method: 'POST',
+  //   url: '/event/trigger',
+  //   handler: (request, reply) => {
+  //     try {
+  //       const evt = RecvEvents.parse(request.headers, request.body);
 
-        if (RecvEvents.isKnownEventType(evt)) {
-          reply.status(422).send({
-            info: `Cloud Event type "${evt.type}" is not known`
-          });
-        } else {
-          RecvEvents.processEvent(evt);
-        }
-      } catch (e) {
-        if (e instanceof ValidationError) {
-          log.warn('error parsing cloud event. event data: %j', {
-            body: request.body,
-            headers: request.headers
-          });
-          log.warn(e);
+  //       if (RecvEvents.isKnownEventType(evt)) {
+  //         reply.status(422).send({
+  //           info: `Cloud Event type "${evt.type}" is not known`
+  //         });
+  //       } else {
+  //         RecvEvents.processEvent(evt);
+  //       }
+  //     } catch (e) {
+  //       if (e instanceof ValidationError) {
+  //         log.warn('error parsing cloud event. event data: %j', {
+  //           body: request.body,
+  //           headers: request.headers
+  //         });
+  //         log.warn(e);
 
-          reply.status(400).send({
-            info: 'Cloud Event validation failed',
-            details: e.errors
-          });
-        } else {
-          reply.status(500).send('internal server error');
-        }
-      }
-    }
-  });
+  //         reply.status(400).send({
+  //           info: 'Cloud Event validation failed',
+  //           details: e.errors
+  //         });
+  //       } else {
+  //         reply.status(500).send('internal server error');
+  //       }
+  //     }
+  //   }
+  // });
 
-  if (NODE_ENV === 'dev') {
-    const GameSchema = Joi.object({
-      uuid: Joi.string()
-    }).default(() => {
-      return { uuid: nanoid() };
-    });
-    const MatchSchema = Joi.object({
-      uuid: Joi.string().default(() => nanoid()),
-      playerA: Joi.string().default(() => nanoid()),
-      playerB: Joi.string().default(() => nanoid())
-    }).default(() => {
-      return {
-        uuid: nanoid(),
-        playerA: nanoid(),
-        playerB: nanoid()
-      };
-    });
-    const AttackSchema = Joi.object({
-      destroyed: Joi.boolean(),
-      hit: Joi.boolean(),
-      origin: Joi.array().length(2).items(Joi.number().integer().max(4).min(0)),
-      type: Joi.string().valid(
-        ShipType.Carrier,
-        ShipType.Battleship,
-        ShipType.Destroyer,
-        ShipType.Submarine
-      )
-    }).default(() => {
-      return {
-        destroyed: false,
-        hit: true,
-        origin: [0, 0],
-        type: ShipType.Destroyer
-      };
-    });
+  // if (NODE_ENV === 'dev') {
+  //   const GameSchema = Joi.object({
+  //     uuid: Joi.string()
+  //   }).default(() => {
+  //     return { uuid: nanoid() };
+  //   });
+  //   const MatchSchema = Joi.object({
+  //     uuid: Joi.string().default(() => nanoid()),
+  //     playerA: Joi.string().default(() => nanoid()),
+  //     playerB: Joi.string().default(() => nanoid())
+  //   }).default(() => {
+  //     return {
+  //       uuid: nanoid(),
+  //       playerA: nanoid(),
+  //       playerB: nanoid()
+  //     };
+  //   });
+  //   const AttackSchema = Joi.object({
+  //     destroyed: Joi.boolean(),
+  //     hit: Joi.boolean(),
+  //     origin: Joi.array().length(2).items(Joi.number().integer().max(4).min(0)),
+  //     type: Joi.string().valid(
+  //       ShipType.Carrier,
+  //       ShipType.Battleship,
+  //       ShipType.Destroyer,
+  //       ShipType.Submarine
+  //     )
+  //   }).default(() => {
+  //     return {
+  //       destroyed: false,
+  //       hit: true,
+  //       origin: [0, 0],
+  //       type: ShipType.Destroyer
+  //     };
+  //   });
 
-    const NewBody = Joi.object({
-      game: GameSchema,
-      match: MatchSchema,
-      attack: AttackSchema
-    });
+  //   const NewBody = Joi.object({
+  //     game: GameSchema,
+  //     match: MatchSchema,
+  //     attack: AttackSchema
+  //   });
 
-    server.route({
-      method: 'POST',
-      url: '/event/send/:type',
-      handler: async (
-        request: FastifyRequest<{ Params: NewEventParams }>,
-        reply
-      ) => {
-        const { params } = request;
+  //   server.route({
+  //     method: 'POST',
+  //     url: '/event/send/:type',
+  //     handler: async (
+  //       request: FastifyRequest<{ Params: NewEventParams }>,
+  //       reply
+  //     ) => {
+  //       const { params } = request;
 
-        const validation = NewBody.validate(
-          request.body || {},
-          DEFAULT_JOI_OPTS
-        );
+  //       const validation = NewBody.validate(
+  //         request.body || {},
+  //         DEFAULT_JOI_OPTS
+  //       );
 
-        if (validation.error) {
-          return reply.status(400).send(validation.error);
-        }
+  //       if (validation.error) {
+  //         return reply.status(400).send(validation.error);
+  //       }
 
-        const body = validation.value as NewEventBody;
+  //       const body = validation.value as NewEventBody;
 
-        log.info(
-          `received request to manually send "${params.type}" cloud event with body: %j`,
-          body
-        );
+  //       log.info(
+  //         `received request to manually send "${params.type}" cloud event with body: %j`,
+  //         body
+  //       );
 
-        const game = new GameConfiguration(
-          body.game.uuid,
-          new Date().toISOString(),
-          GameState.Active
-        );
-        const match = new MatchInstance(
-          body.match.playerA,
-          body.match.playerB,
-          undefined,
-          undefined,
-          body.match?.uuid
-        );
-        const player = new Player({
-          uuid: match.getPlayers().playerA,
-          username: generateUserName(),
-          isAi: false
-        });
-        player.setShipPositionData(player.getShipPositionData(), true);
-        const opponent = new Player({
-          uuid: match.getPlayers().playerB,
-          username: generateUserName(),
-          isAi: true
-        });
-        opponent.setShipPositionData(opponent.getShipPositionData(), true);
+  //       const game = new GameConfiguration(
+  //         body.game.uuid,
+  //         new Date().toISOString(),
+  //         GameState.Active
+  //       );
+  //       const match = new MatchInstance(
+  //         body.match.playerA,
+  //         body.match.playerB,
+  //         undefined,
+  //         undefined,
+  //         body.match?.uuid
+  //       );
+  //       const player = new Player({
+  //         uuid: match.getPlayers().playerA,
+  //         username: generateUserName(),
+  //         isAi: false
+  //       });
+  //       player.setShipPositionData(player.getShipPositionData(), true);
+  //       const opponent = new Player({
+  //         uuid: match.getPlayers().playerB,
+  //         username: generateUserName(),
+  //         isAi: true
+  //       });
+  //       opponent.setShipPositionData(opponent.getShipPositionData(), true);
 
-        if (params.type === SendEvents.EventType.Attack) {
-          await SendEvents.attack(game, match, player, opponent, body.attack);
-          return `queued "${params.type}" cloud event`;
-        } else if (params.type === SendEvents.EventType.MatchStart) {
-          await SendEvents.matchStart(game, match, player, opponent);
-          return `queued "${params.type}" cloud event`;
-        } else if (params.type === SendEvents.EventType.MatchEnd) {
-          await SendEvents.matchEnd(game, match, player, opponent);
-          return `queued "${params.type}" cloud event`;
-        } else {
-          return reply.send(`unknown event type: "${params.type}"`);
-        }
-      }
-    });
-  }
+  //       if (params.type === SendEvents.EventType.Attack) {
+  //         await SendEvents.attack(game, match, player, opponent, body.attack);
+  //         return `queued "${params.type}" cloud event`;
+  //       } else if (params.type === SendEvents.EventType.MatchStart) {
+  //         await SendEvents.matchStart(game, match, player, opponent);
+  //         return `queued "${params.type}" cloud event`;
+  //       } else if (params.type === SendEvents.EventType.MatchEnd) {
+  //         await SendEvents.matchEnd(game, match, player, opponent);
+  //         return `queued "${params.type}" cloud event`;
+  //       } else {
+  //         return reply.send(`unknown event type: "${params.type}"`);
+  //       }
+  //     }
+  //   });
+  // }
 
   done();
 };

--- a/src/sockets/handler.attack.ts
+++ b/src/sockets/handler.attack.ts
@@ -1,6 +1,5 @@
 import log from '@app/log';
 import * as matchmaking from '@app/stores/matchmaking';
-import * as players from '@app/stores/players';
 import { GameState } from '@app/models/game.configuration';
 import * as ce from '@app/cloud-events/send';
 import { isGameOverForPlayer } from '@app/game';

--- a/src/sockets/handler.attack.ts
+++ b/src/sockets/handler.attack.ts
@@ -32,30 +32,19 @@ const attackHandler: MessageHandler<
   AttackDataPayload,
   MergedAttackReponse | ValidationErrorPayload
 > = async (container: PlayerSocketDataContainer, attack: AttackDataPayload) => {
-  const info = container.getPlayerInfo();
+  const basePlayer = container.getPlayer();
 
-  if (!info) {
+  if (!basePlayer) {
     throw new Error('failed to find player associated with this websocket');
   }
 
-  // Despite the fact a player is associated with a socket, we always
-  // use the cache as a source of truth. The socket is a lookup reference
-  const player = await players.getPlayerWithUUID(info.uuid);
-  if (!player) {
-    throw new Error('failed to find player data');
-  }
-
-  const { game, opponent, match } = await getPlayerSpecificData(player);
+  const { game, match, opponent, player } = await getPlayerSpecificData(
+    basePlayer
+  );
 
   if (!game.isInState(GameState.Active)) {
     throw new Error(
       `player ${player.getUUID()} cannot attack when game state is "${game.getGameState()}"`
-    );
-  }
-
-  if (!match) {
-    throw new Error(
-      `failed to find match associated with player ${player.getUUID()}`
     );
   }
 
@@ -124,12 +113,6 @@ const attackHandler: MessageHandler<
     );
   }
 
-  // Save both updated player objects to cache
-  await Promise.all([
-    players.upsertPlayerInCache(player),
-    players.upsertPlayerInCache(opponent)
-  ]);
-
   if (isGameOverForPlayer(opponent)) {
     log.info(
       `determined that player ${opponent.getUUID()} lost match ${match.getUUID()} against ${player.getMatchInstanceUUID()}`
@@ -161,7 +144,7 @@ const attackHandler: MessageHandler<
       data: {
         result: attackResult,
         attacker: player.getUUID(),
-        ...new PlayerConfiguration(game, opponent, match, player).toJSON()
+        ...new PlayerConfiguration(game, opponent, match).toJSON()
       }
     });
   }
@@ -172,7 +155,7 @@ const attackHandler: MessageHandler<
     data: {
       result: attackResult,
       attacker: player.getUUID(),
-      ...new PlayerConfiguration(game, player, match, opponent).toJSON()
+      ...new PlayerConfiguration(game, player, match).toJSON()
     }
   };
 };

--- a/src/sockets/handler.bonus.ts
+++ b/src/sockets/handler.bonus.ts
@@ -1,4 +1,3 @@
-import * as players from '@app/stores/players';
 import { GameState } from '@app/models/game.configuration';
 import { MessageHandler } from './common';
 import { BonusDataPayload } from '@app/payloads/incoming';

--- a/src/sockets/handler.ship-positions.ts
+++ b/src/sockets/handler.ship-positions.ts
@@ -3,7 +3,6 @@ import { GameState } from '@app/models/game.configuration';
 import PlayerConfiguration, {
   PlayerConfigurationData
 } from '@app/models/player.configuration';
-import * as players from '@app/stores/players';
 import { ShipPositionData } from '@app/game/types';
 import { validateShipPlacement } from '@app/game';
 import { OutgoingMsgType } from '@app/payloads/outgoing';

--- a/src/sockets/player.socket.container.ts
+++ b/src/sockets/player.socket.container.ts
@@ -21,7 +21,7 @@ export default class PlayerSocketDataContainer {
   private sequence = 0;
   private lastRecvTs!: number;
   private kickTimer: NodeJS.Timeout;
-  private player!: Player;
+  private player: Player | undefined;
 
   constructor(private ws: WebSocket) {
     this.kickTimer = setInterval(() => {
@@ -63,7 +63,7 @@ export default class PlayerSocketDataContainer {
       } else {
         log.warn(
           'Attempted to send message on closed socket for player: %j',
-          this.player.getUUID()
+          this.player?.getUUID()
         );
       }
     } catch (error) {
@@ -74,7 +74,7 @@ export default class PlayerSocketDataContainer {
   async processMessage(data: WebSocket.Data) {
     if (this.isLocked()) {
       log.warn(
-        "client sent a message, but we're already processing one on their behalf"
+        `cannot process message for ${this.getPlayer()?.getUUID()} (ai: ${this.getPlayer()?.isAiPlayer()}). We're already processing one on their behalf!`
       );
       this.send({
         type: OutgoingMsgType.PleaseWait,

--- a/src/sockets/player.socket.container.ts
+++ b/src/sockets/player.socket.container.ts
@@ -1,5 +1,6 @@
 import { NODE_ENV, WS_ACTIVITY_TIMEOUT } from '@app/config';
 import log from '@app/log';
+import Player from '@app/models/player';
 import { WsPayload } from '@app/payloads/incoming';
 import { OutgoingMsgType } from '@app/payloads/outgoing';
 import { DEFAULT_JOI_OPTS, WsPayloadSchema } from '@app/payloads/schemas';
@@ -20,9 +21,7 @@ export default class PlayerSocketDataContainer {
   private sequence = 0;
   private lastRecvTs!: number;
   private kickTimer: NodeJS.Timeout;
-  private playerInfo:
-    | undefined
-    | { uuid: string; username: string } = undefined;
+  private player!: Player;
 
   constructor(private ws: WebSocket) {
     this.kickTimer = setInterval(() => {
@@ -37,14 +36,14 @@ export default class PlayerSocketDataContainer {
       ) {
         log.info(
           `kicking inactive socket for player ${
-            this.playerInfo?.uuid || '*uninitialised*'
+            this.player?.getUUID() || '*uninitialised*'
           }`
         );
         this.close();
       } else {
         log.trace(
           `not kicking player/socket ${
-            this.playerInfo?.uuid || '*uninitialised*'
+            this.player?.getUUID() || '*uninitialised*'
           } since they've been active`
         );
       }
@@ -64,7 +63,7 @@ export default class PlayerSocketDataContainer {
       } else {
         log.warn(
           'Attempted to send message on closed socket for player: %j',
-          this.playerInfo
+          this.player.getUUID()
         );
       }
     } catch (error) {
@@ -175,12 +174,12 @@ export default class PlayerSocketDataContainer {
     this.locked = false;
   }
 
-  setPlayerInfo(info: { uuid: string; username: string }) {
-    this.playerInfo = info;
+  setPlayer(player: Player) {
+    this.player = player;
   }
 
-  getPlayerInfo() {
-    return this.playerInfo;
+  getPlayer() {
+    return this.player;
   }
 
   getSequenceNumber() {

--- a/src/sockets/player.sockets.ts
+++ b/src/sockets/player.sockets.ts
@@ -32,8 +32,8 @@ export function getSocketDataContainer(ws: WebSocket) {
  * Retrieve the player data associated with a given WebSocket
  * @param ws
  */
-export function getPlayerDataAssociatedWithSocket(ws: WebSocket) {
-  return socks.get(ws)?.getPlayerInfo();
+export function getPlayerAssociatedWithSocket(ws: WebSocket) {
+  return socks.get(ws)?.getPlayer();
 }
 
 /**
@@ -53,7 +53,7 @@ export function getSocketDataContainerByPlayerUUID(
 ): PlayerSocketDataContainer | undefined {
   log.trace(`starting socket lookup for player ${uuid}`);
   for (const entry of socks) {
-    if (entry[1].getPlayerInfo()?.uuid === uuid) {
+    if (entry[1].getPlayer()?.getUUID() === uuid) {
       log.trace(`socket lookup success for player ${uuid}`);
       return entry[1];
     }

--- a/src/stores/matchmaking/index.ts
+++ b/src/stores/matchmaking/index.ts
@@ -3,7 +3,7 @@ import pLimit from 'p-limit';
 import getDataGridClientForCacheNamed from '@app/datagrid/client';
 import log from '@app/log';
 import MatchInstance, { MatchInstanceData } from '@app/models/match.instance';
-import Player, { UnmatchedPlayerData, PlayerData } from '@app/models/player';
+import Player, { UnmatchedPlayerData } from '@app/models/player';
 import { DATAGRID_MATCH_DATA_STORE } from '@app/config';
 
 const getClient = getDataGridClientForCacheNamed(DATAGRID_MATCH_DATA_STORE);


### PR DESCRIPTION
This reduces Infinispan queries by quite a bit. Previously each message required:

1. Read the player
2. Read the match
3. Read the opponent

This was because the player board and other state was stored on a "Player" model in a "players" store in Infinispan. This refactor moves that state into the match itself. The player store in Infinispan only contains a player's:

* uuid
* username
* match uuid
* ai boolean flag

The match UUID can be associated with the in-memory player object/socket to simplify lookups so we generally just perform a single query to load the match from Inifinispan.

Another benefit to this is that we also perform just a single write too.

Oh, and the opponent UUID is not revealed anymore either.

Needs a little more testing but seems solid.